### PR TITLE
Improved the interaction of error messages

### DIFF
--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -22,13 +22,18 @@ $(document).ready(function () {
       return $('<p class="subscribe-form-output"></p>')
         .text(text)
         .addClass(className)
-        .appendTo($this)
+        .insertAfter($submit)
         .hide()
         .slideDown();
     };
 
     $this.submit(function (e) {
       e.preventDefault();
+
+      if ($this.find('.subscribe-form-email').val().trim() === "") {
+        createFlash('Must provide email', 'subscribe-form-error');
+        return;
+      }
 
       if (loading != null) {
         return;

--- a/views/index.html
+++ b/views/index.html
@@ -7,7 +7,7 @@
     <form class="subscribe-form landing-welcome-subscribe-form" action="/api/subscribe" method="POST">
       <label class="sr-only" for="subscribe-form-email">Email</label>
       <div class="subscribe-form-input-container">
-        <input type="email" class="subscribe-form-email" placeholder="Email Address" id="subscribe-form-email" name="email">
+        <input type="email" class="subscribe-form-email" placeholder="Email Address" id="subscribe-form-email" name="email" required>
         <div class="subscribe-form-underbar"></div>
       </div>
       <button type="submit" class="subscribe-form-submit">Notify me when applications open</button>


### PR DESCRIPTION
Trying to enter a blank email address will show an error immediately, instead of a flash of “Working…”. Additionally, consecutive error messages appear at the top, rather than at the bottom.