### PR TITLE
Improve legibility of text

### DIFF
--- a/assets/styles/home.styl
+++ b/assets/styles/home.styl
@@ -250,7 +250,7 @@ a.apply-link {
   }
   
   p {
-    font-size: 0.8em;
+    font-size: 0.9em;
     opacity: 0.9;
   }
 

--- a/assets/styles/layout.styl
+++ b/assets/styles/layout.styl
@@ -7,6 +7,8 @@ body {
 
   font-family: $fontFamily;
   font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
   line-height: 1.5;
   color: $textColor;
 
@@ -102,26 +104,31 @@ h1 {
 }
 
 h2 {
+  font-weight: normal;
   font-size: 1.2 * 1.2;
   line-height: 1.2;
 }
 
 h3 {
+  font-weight: normal;
   font-size: 1.2em;
   line-height: 1.2;
 }
 
 h4 {
+  font-weight: bold;
   font-size: 1em;
   line-height: 1.2;
 }
 
 h5 {
+  font-weight: bold;
   font-size: 1 / 1.2;
   line-height: 1.2;
 }
 
 h6 {
+  font-weight: bold;
   font-size: 1 / 1.2 / 1.2;
   line-height: 1.2;
 }
@@ -140,7 +147,7 @@ ol, ul {
   }
 }
 
-h1, h2, h3, .grand-heading {
+h1, .grand-heading {
   font-weight: 300;
 }
 


### PR DESCRIPTION
Safari does some weird stuff with font smoothing, so does Chrome. We're doing this to make things a little less jagged and bloaty. See comparison images below. Also shifted the weight/size of a few things to aid with readability.

I tried my best to see how this would look on non-retina screens, but this is just going to be something we'll have to keep our eyes on.

# Chrome

## Before

![screen shot 2016-10-25 at 8 35 00 pm](https://cloud.githubusercontent.com/assets/3238878/19701447/5e27b6b6-9af3-11e6-836d-060808a59ef0.png)

![screen shot 2016-10-25 at 8 27 01 pm](https://cloud.githubusercontent.com/assets/3238878/19701437/52db1942-9af3-11e6-968b-ddcaa779d57c.png)

## After

![screen shot 2016-10-25 at 8 35 00 pm](https://cloud.githubusercontent.com/assets/3238878/19701455/667c42be-9af3-11e6-94e2-4014f795f2e3.png)

![screen shot 2016-10-25 at 8 28 58 pm](https://cloud.githubusercontent.com/assets/3238878/19701459/6ae7325a-9af3-11e6-8036-f8a2937e5824.png)

# Safari

## Before

![screen shot 2016-10-25 at 8 34 45 pm](https://cloud.githubusercontent.com/assets/3238878/19701477/7fd7ee84-9af3-11e6-9596-4c0b96858d1f.png)

## After

![screen shot 2016-10-25 at 8 34 38 pm](https://cloud.githubusercontent.com/assets/3238878/19701482/8392c9e0-9af3-11e6-96ce-130eff058844.png)

@jaredkhan could you review?

