### PR TITLE
Fix image flickering in Safari

### DIFF
--- a/assets/styles/home.styl
+++ b/assets/styles/home.styl
@@ -245,7 +245,7 @@ a.apply-link {
     opacity: 1;
     left: 0;
     bottom: 0;
-
+    -webkit-transform: translate3d(0,0,0); // fixes flickering image on safari
     transition: opacity 0.2s;
   }
   


### PR DESCRIPTION
When animating transitions Safari renders images differently. This means they can appear slightly
displaced for the duration of the animation. You can force Safari to render the images
the same way by using the added rule. Isn't Safari charming.