### PR TITLE
Allow logo to be cache busted

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -2,7 +2,7 @@
 {% block content %}
 <section class="landing-welcome-section">
   <div class="landing-welcome-content">
-    <img class="landing-welcome-logo" src="assets/images/logos/hc2017-logo-vertical-light.svg" alt="Hack Cambridge: Recurse">
+    <img class="landing-welcome-logo" src="{{ asset('images/logos/hc2017-logo-vertical-light.svg') }}" alt="Hack Cambridge: Recurse">
     <p class="landing-welcome-dates">28 &ndash; 29 January 2017, University of Cambridge</p>
     <form class="subscribe-form landing-welcome-subscribe-form" action="/api/subscribe" method="POST">
       <label class="sr-only" for="subscribe-form-email">Email</label>


### PR DESCRIPTION
Our new logo's URL is hardcoded, which doesn't allow us to leverage our beatiful asset hashing for cache busting, such as `/assets/images/logos/hc2017-logo-horizontal-color.c53d2942.svg`.

Simple fix!

@varkor could you review?