### PR TITLE
Centred text on 404 page

### DIFF
--- a/src/views/404.html
+++ b/src/views/404.html
@@ -2,5 +2,7 @@
 {% set title = '404 Not Found | Hack Cambridge' %}
 {% block pageHeading %}Not Found{% endblock %}
 {% block pageContent %}
-<p>Sorry, we couldn't find what you were looking for.</p>
+<div class="content-wrapper-center">   
+  <p>Sorry, we couldn't find what you were looking for.</p>
+</div>
 {% endblock %}


### PR DESCRIPTION
Tiny change, but makes the 404 page look a little more cohesive, as there’s no longer just a single line of left-aligned text.

@Pinpickle — could you review? (Also: as this pattern has cropped up before, not sure if it's worth just having a `pageContentCentred` block or something like that instead?)