### PR TITLE
Fix a footer positioning problem in Safari

### DIFF
--- a/src/styles/home.styl
+++ b/src/styles/home.styl
@@ -134,6 +134,13 @@ a.signin-link {
       }
     }
   }
+
+  @media only screen and (min-height: 700px) {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 0px;
+  }
 }
 
 .landing-welcome-background {

--- a/src/styles/home.styl
+++ b/src/styles/home.styl
@@ -134,11 +134,6 @@ a.signin-link {
       }
     }
   }
-
-  @media only screen and (min-height: 700px) {
-    position: absolute;
-    bottom: 0px;
-  }
 }
 
 .landing-welcome-background {


### PR DESCRIPTION
The home footer now stays centre on Safari regardless of window size. This fixes #111.