### PR TITLE
Fix https in generating absolute urls

### DIFF
--- a/src/js/server/index.js
+++ b/src/js/server/index.js
@@ -28,20 +28,12 @@ process.on('unhandledRejection', (reason, promise) => {
 
 utils.init(app);
 
-app.use(function(req, res, next) {
-  // Force https
-  if ((req.headers['x-forwarded-proto'] != 'https') && (process.env.FORCE_HTTPS == "1")) {
-    res.redirect('https://' + req.hostname + req.originalUrl);
-  } else {
-    next();
-  }
-});
-
 app.use(function (req, res, next) {
   res.locals.title = 'Hack Cambridge';
-  const port = (app.settings.env == "development") ? ':' + req.app.settings.port : '';
+  const port = (app.settings.env == 'development') ? ':' + req.app.settings.port : '';
+  const protocol = (app.settings.env == 'development') ? req.protocol : 'https';
   res.locals.requestedUrl = req.requestedUrl = url.parse(
-    req.protocol + '://' + req.hostname + port + req.originalUrl
+    protocol + '://' + req.hostname + port + req.originalUrl
   );
   next();
 });


### PR DESCRIPTION
`req.requestedUrl` was giving us http even when people are being served https. This is due to the fact that our https is handled by Cloudflare and Heroku, and the actual app is serving http.

While I was fixing this, I also removed the https check as Cloudflare does that for us as well.

@jaredkhan could you review?