### PR TITLE
Improve layout on small screens

### DIFF
--- a/src/styles/apply.styl
+++ b/src/styles/apply.styl
@@ -9,8 +9,13 @@
 }
 .logged-in {
   padding: 10px;
-  background: $colorSecondary;
+  background: transparentify($colorSecondary, 0.6);
   color: white;
+  position: absolute;
+  top:0;
+  left:0;
+  right:0;
+  z-index: 10;
 }
 .status-message {
   display: inline-block;

--- a/src/styles/layout.styl
+++ b/src/styles/layout.styl
@@ -101,6 +101,19 @@ content-wrapper-left() {
   margin-right: auto;
   width: 600px;
 }
+@media screen and (max-width: 600px) {
+  .long-text {
+    display: none;
+  }
+}
+.short-text {
+  display: none;
+}
+@media screen and (max-width: 600px) {
+  .short-text {
+    display: inline;
+  }
+}
 
 /* Typography
    ========================================================================== */

--- a/src/views/apply/dashboard.html
+++ b/src/views/apply/dashboard.html
@@ -8,7 +8,7 @@
 </header>
 
   {# The main status banner #}
-  <div class="content-wrapper-center">
+  <center>
     <div class="status-message {{ statusMessage.message_type }}">
       <h2>{{ statusMessage.title }}</h2>
       <span>{{ statusMessage.subline }}</span>
@@ -20,7 +20,7 @@
       <code>{{ applicationSlug }}</code>
     </div>
   {% endif %}
-  </div>
+  </center>
   
   
   

--- a/src/views/base.html
+++ b/src/views/base.html
@@ -25,11 +25,11 @@
       if the user variable is available (only the case if the page is authenticated) let them know they're logged in via a header
     #}
     {% if user.firstName %}
-      <header class="logged-in">
-        Logged in as {{ user.firstName }} {{ user.lastName }} &nbsp; <a href="/apply/logout">Logout</a>
+      <header class="logged-in clearfix">
+        <span class="long-text">Logged in as</span> {{ user.firstName }} {{ user.lastName }} &nbsp; <a href="/apply/logout">Logout</a>
         {# dashboard view explicitly sets is_dashboard to true, otherwise is falsey #}
         {% if not is_dashboard %}
-          <a class="float-right" href="/apply/dashboard">Go to your dashboard &rarr;</a>
+          <a class="float-right" href="/apply/dashboard"><span class="long-text">Go to your dashboard</span><span class="short-text">Dashboard</span> &rarr;</a>
         {% endif %}
       </header>
     {% endif %}


### PR DESCRIPTION
Make the logged in banner collapse nicer and address concerns of it meddling with the full height homepage by making it float. Transparency is up for debate. Also remove the content wrapper from the Dashboard to make the padding better on mobile.

<img width="352" alt="screen shot 2016-11-14 at 15 29 33" src="https://cloud.githubusercontent.com/assets/3105017/20270514/4615de90-aa7f-11e6-965a-8edd55441ccb.png">


