### PR TITLE
Restrict applications from ineligible people

### DIFF
--- a/src/js/server/auth.js
+++ b/src/js/server/auth.js
@@ -39,6 +39,11 @@ exports.setUpAuth = function (app) {
 
   app.use(setUserFromSession);
   app.get('/auth/callback', handleCallback);
+  app.get('/auth/error', (req, res) => {
+    res.render('auth/error.html', {
+      errorCode: req.query.code,
+    });
+  });
 }
 
 // Ensures that there is user data available, otherwise redirects to authenticate the user
@@ -104,6 +109,11 @@ function handleCallback(req, res, next) {
         // Redirect with auth
         res.redirect(redirectTo);
       }).catch(err => {
+        if (err instanceof Hacker.TooYoungError) {
+          res.redirect('/auth/error?code=TOO_YOUNG')
+          return;
+        }
+
         console.log('Error logging a user in');
         next(err);
       });

--- a/src/js/shared/application-form.js
+++ b/src/js/shared/application-form.js
@@ -133,6 +133,13 @@ exports.createApplicationForm = function createApplicationForm(validateFile = tr
       ],
       cssClasses,
     }),
+    student_status: fields.boolean({
+      label: 'Please confirm your student status:',
+      note: '',
+      widget: checkboxWidget('I am currently a student or I graduated after January 28th 2016.'),
+      required: validators.matchValue(() => true, 'You must confirm your student status to apply.'),
+      cssClasses,
+    }),
     terms: fields.boolean({
       label: 'Do you accept our <a href="/terms" target="_blank">terms and conditions</a> and <a href="/privacy" target="_blank">privacy policy</a>?',
       note: 'This includes the <a href="http://static.mlh.io/docs/mlh-code-of-conduct.pdf" target="_blank">MLH Code of Conduct</a>.',

--- a/src/js/shared/dates.js
+++ b/src/js/shared/dates.js
@@ -1,0 +1,5 @@
+const moment = require('moment');
+
+exports.getHackathonStartDate = function () {
+  return moment('2017-01-28');
+};

--- a/src/views/auth/error.html
+++ b/src/views/auth/error.html
@@ -1,0 +1,9 @@
+{% extends 'default.html' %}
+{% set title = 'Authentication Error' %}
+{% block pageHeading %}We're Sorry{% endblock %}
+{% block pageContent %}
+{% if errorCode === 'TOO_YOUNG' %}
+<p>Unfortunately, due to legal reasons, only people who are 18 or over on the day of the hackathon can attend &#x1F61E;</p>
+<p>But don't let that put you off! We look forward to seeing you at a later event!</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
This stops under 18s and people who have graduated too long ago from applying.

Under 18s, when trying to log in will see this. A user is not created:

![image](https://cloud.githubusercontent.com/assets/3238878/20391058/8cf737d6-acc9-11e6-8a1c-1b717fe7c72d.png)

When applying there is now another mandatory checkbox, a la terms and conditions:

![image](https://cloud.githubusercontent.com/assets/3238878/20391089/bbe0920e-acc9-11e6-8a5a-cc039c543ffe.png)

@varkor could you review? I would love some recommendations on copy as well!

