### PR TITLE
Fix date for graduation on FAQ

### DIFF
--- a/src/resources/faqs.yml
+++ b/src/resources/faqs.yml
@@ -3,7 +3,7 @@ faqs:
     answer: A hackathon is a focused 24-hour event where you and a small team get to build something new and exciting, alongside a whole bunch of likeminded people.
 
   - question: Can I attend?
-    answer: If you're 18 or over, and a student at any university, or were still a student after the 30<sup>th</sup> of January 2015, you're welcome at apply.
+    answer: If you're 18 or over, and a student at any school or university, or were still a student after the 28<sup>th</sup> of January 2016, you're welcome at apply.
 
   - question: Do I have to be doing Computer Science or other programming-related degree to take part?
     answer: No — we welcome everyone to apply whatever your subject or university!


### PR DESCRIPTION
We had someone kindly point out to us that our FAQ specified the wrong maximum graduation date.

That's been fixed in this PR. Also cleared up some wording around "university" because we do allow high school students that are 18 or over (and we've had some people ask).

@varkor could you review?