### PR TITLE
Add oauth API

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,27 @@ We are using the sequelize CLI to manage migrations. So to create your own:
 npm run sequelize -- migration:create --name YOURMIGRATION
 ```
 
+## OAuth2 API
+
+We run an API which authenticates admin users via tokens. Currently the only way to create tokens is
+through scripts. To create a user:
+
+```
+npm run hc-script -- create-admin --email email@domain.com --name UserName
+```
+
+To then create a token for that user:
+
+```
+npm run hc-script -- create-token email@domain.com
+```
+
+Once you have your token, you can use it to authenticate requests to the API in your HTTP headers:
+
+```
+Authorization: Bearer <<TOKEN GOES HERE >>
+```
+
 ## Build System
 
 This uses [Gulp](http://gulpjs.org). Install it globally, and then run to build styles and scripts.
@@ -80,6 +101,7 @@ gulp watch # Watch for changes in assets and build automatically
 gulp build --prod # Build production assets (or set NODE_ENV to production)
 ```
 
-## Deploying
+## Rolling your own
 
-Deploying is done manually through Heroku interface.
+Want to run this in production? Hack Cambridge runs on [Heroku](https://heroku.com) so we recommend that. This application
+handles a lot of sensitive user data so you'll want to make sure **https is implemented and enforced**.

--- a/db/migrations/20161206000716-hcapi.js
+++ b/db/migrations/20161206000716-hcapi.js
@@ -1,0 +1,81 @@
+'use strict';
+
+function createAdminTable(queryInterface, Sequelize) {
+  return queryInterface.createTable('admins', {
+    id: {
+      type: Sequelize.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+      allowNull: false,
+    },
+    createdAt: {
+      type: Sequelize.DATE,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: Sequelize.DATE,
+      allowNull: false,
+    },
+    name: {
+      type: Sequelize.TEXT,
+      allowNull: false,
+    },
+    email: {
+      type: Sequelize.TEXT,
+      allowNull: false,
+      unique: true,
+    }
+  });
+}
+
+function createOauthAccessTokenTable(queryInterface, Sequelize) {
+  return queryInterface.createTable('oauth-access-tokens', {
+    id: {
+      type: Sequelize.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+      allowNull: false,
+    },
+    createdAt: {
+      type: Sequelize.DATE,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: Sequelize.DATE,
+      allowNull: false,
+    },
+    token: {
+      type: Sequelize.UUID,
+      unique: true,
+      primaryKey: true,
+      defaultValue: Sequelize.UUIDV4,
+      allowNull: false,
+    },
+    expiresOn: {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: () => moment().add(2, 'months').toDate(),
+    },
+    adminId: {
+      allowNull: false,
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'admins',
+        key: 'id',
+        deferrable:  Sequelize.Deferrable.INITIALLY_IMMEDIATE
+      },
+    },
+  });
+}
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    return createAdminTable(queryInterface, Sequelize)
+      .then(() => createOauthAccessTokenTable(queryInterface, Sequelize));
+  },
+
+  down: function (queryInterface, Sequelize) {
+    return queryInterface.dropTable('oauth-access-tokens')
+      .then(() => queryInterface.dropTable('admins'));
+  }
+};

--- a/hc-script.js
+++ b/hc-script.js
@@ -2,4 +2,4 @@ try {
   require('dotenv').load();
 } catch (e) { }
 
-require('js/server');
+require('js/hc-scripts');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "export NODE_PATH=$NODE_PATH:./src; node ./index",
     "postinstall": "gulp build",
     "migrate": "sequelize db:migrate",
-    "sequelize": "sequelize"
+    "sequelize": "sequelize",
+    "hc-script": "export NODE_PATH=$NODE_PATH:./src; node ./hc-script"
   },
   "repository": {
     "type": "git",
@@ -73,6 +74,8 @@
     "nodemon": "^1.8.1",
     "normalize.css": "^3.0.3",
     "nunjucks": "^2.1.0",
+    "passport": "^0.3.2",
+    "passport-http-bearer": "^1.0.1",
     "pepjs": "^0.4.1",
     "pg": "^6.1.0",
     "pg-hstore": "^2.3.2",
@@ -87,7 +90,7 @@
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "webpack": "^1.12.2",
-    "yargs": "^3.29.0"
+    "yargs": "^6.5.0"
   },
   "devDependencies": {
     "eslint": "^1.8.0",

--- a/src/js/hc-scripts/create-admin.js
+++ b/src/js/hc-scripts/create-admin.js
@@ -1,0 +1,16 @@
+const { Admin } = require('js/server/models');
+const yargs = require('yargs');
+const { createHandler } = require('./utils');
+
+module.exports = {
+  command: 'create-admin',
+  desc: 'Create a new admin user',
+  aliases: [],
+  builder(yargs) {
+    return yargs.demand(['email', 'name']);
+  },
+  handler: createHandler(({ name, email }) =>
+    Admin.create({ name, email })
+      .then(admin => console.log('New admin created', admin.get()))
+  ),
+};

--- a/src/js/hc-scripts/create-token.js
+++ b/src/js/hc-scripts/create-token.js
@@ -1,0 +1,24 @@
+const { Admin, OauthAccessToken } = require('js/server/models');
+const yargs = require('yargs');
+const { createHandler } = require('./utils');
+
+module.exports = {
+  command: 'create-token <email>',
+  desc: 'Create an oauth token for an admin',
+  aliases: [],
+  builder(yargs) {
+    return yargs;
+  },
+  handler: createHandler(({ email }) =>
+    Admin.findOne({ where: { email }})
+      .then(admin => {
+        if (!admin) {
+          throw new Error(`No admin found with email ${email}`);
+        }
+
+        return admin;
+      })
+      .then(admin => OauthAccessToken.create({ adminId: admin.id }))
+      .then(token => console.log(`New access token: ${token.token}`))
+  ),
+};

--- a/src/js/hc-scripts/index.js
+++ b/src/js/hc-scripts/index.js
@@ -1,0 +1,11 @@
+const yargs = require('yargs');
+
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('Unhandled rejection at: Promise', promise, 'reason', reason);
+});
+
+yargs
+  .command(require('./create-admin'))
+  .command(require('./create-token'))
+  .help()
+  .argv;

--- a/src/js/hc-scripts/utils.js
+++ b/src/js/hc-scripts/utils.js
@@ -1,0 +1,11 @@
+/**
+ * Wraps a function returning a promise designed to handle script commands to automatically catch
+ * errors and kill the process on finish.
+ */
+exports.createHandler = function createHandler(createHandlerFn) {
+  return (...args) => {
+    createHandlerFn(...args)
+      .catch(error => console.error(error))
+      .then(() => process.exit());
+  };
+};

--- a/src/js/server/hcapi/errors.js
+++ b/src/js/server/hcapi/errors.js
@@ -1,0 +1,19 @@
+const { Router } = require('express');
+
+exports.createHttpError = function createError(status, message) {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+};
+
+exports.middleware = {
+  notFound(req, res, next) {
+    next(exports.createHttpError(404, 'Not Found'));
+  },
+  error(error, req, res, next) {
+    console.error(error);
+    res.status(error.status || 500).json({
+      error: error.message || 'An error occurred',
+    });
+  },
+};

--- a/src/js/server/hcapi/index.js
+++ b/src/js/server/hcapi/index.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const passport = require('passport');
+const BearerStrategy = require('passport-http-bearer');
+const { Admin, OauthAccessToken } = require('js/server/models');
+const errors = require('./errors');
+
+passport.use(new BearerStrategy((token, done) => {
+  OauthAccessToken.getAdminFromTokenString(token)
+    .then((admin) => {
+      if (!admin) {
+        done(null, false);
+        return;
+      }
+
+      done(null, admin, { scope: 'all' });
+    })
+    .catch(error => done(error));
+}));
+
+/**
+ * The hcapi is a separate express app to completely separate anything going on in our main website
+ */
+const hcapi = express();
+
+hcapi.use(passport.authenticate('bearer', { session: false }));
+hcapi.use(bodyParser.json());
+
+// API endpoints
+hcapi.use('/tokens', require('./tokens'));
+
+// Errors
+hcapi.use(errors.middleware.notFound);
+hcapi.use(errors.middleware.error);
+
+module.exports = hcapi;

--- a/src/js/server/hcapi/tokens.js
+++ b/src/js/server/hcapi/tokens.js
@@ -1,0 +1,26 @@
+const { Router } = require('express');
+const { OauthAccessToken } = require('js/server/models');
+const { createHttpError } = require('./errors');
+
+const tokensRouter = new Router();
+
+/**
+ * Gets information for a particular access token
+ */
+tokensRouter.get('/:token', (req, res, next) => {
+  OauthAccessToken.findOne({
+    where: {
+      token: req.params.token,
+    },
+  }).then((token) => {
+    if (!token) {
+      throw createHttpError(404, 'Not Found');
+    }
+
+    res.json({
+      token
+    });
+  }).catch(next);
+});
+
+module.exports = tokensRouter;

--- a/src/js/server/index.js
+++ b/src/js/server/index.js
@@ -70,8 +70,7 @@ if (process.env.BS_SNIPPET) {
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use('/api', require('./api'));
 app.use('/apply', require('./apply/router'));
-
-
+app.use('/hcapi', require('./hcapi'));
 
 function renderHome(req, res) {
   res.render('index.html', {

--- a/src/js/server/models/Admin.js
+++ b/src/js/server/models/Admin.js
@@ -1,0 +1,16 @@
+const Sequelize = require('sequelize');
+const db = require('./db');
+
+const Admin = module.exports = db.define('admin', {
+  name: {
+    type: Sequelize.TEXT,
+    allowNull: false,
+  },
+  email: {
+    type: Sequelize.TEXT,
+    allowNull: false,
+    unique: true,
+  },
+}, {
+  tableName: 'admins',
+});

--- a/src/js/server/models/OauthAccessToken.js
+++ b/src/js/server/models/OauthAccessToken.js
@@ -1,0 +1,49 @@
+const Sequelize = require('sequelize');
+const moment = require('moment');
+const db = require('./db');
+const Admin = require('./Admin');
+
+const OauthAccessToken = module.exports = db.define('oauthAccessToken', {
+  token: {
+    type: Sequelize.UUID,
+    unique: true,
+    primaryKey: true,
+    defaultValue: Sequelize.UUIDV4,
+    allowNull: false,
+  },
+  expiresOn: {
+    type: Sequelize.DATE,
+    allowNull: false,
+    defaultValue: () => moment().add(2, 'months').toDate(),
+  },
+  adminId: {
+    allowNull: false,
+    type: Sequelize.INTEGER,
+  },
+}, {
+  tableName: 'oauth-access-tokens',
+});
+
+OauthAccessToken.belongsTo(Admin);
+
+OauthAccessToken.getAdminFromTokenString = function getAdminFromTokenString(token) {
+  return OauthAccessToken.findOne({
+    include: [
+      {
+        model: Admin,
+        required: true,
+      },
+    ],
+    where: {
+      token,
+    },
+  }).then((token) => {
+    if (!token) {
+      return null;
+    }
+
+    return token.admin;
+  });
+}
+
+module.exports = OauthAccessToken;

--- a/src/js/server/models/index.js
+++ b/src/js/server/models/index.js
@@ -5,6 +5,8 @@ const HackerApplication = require('./HackerApplication');
 const ApplicationResponse = require('./ApplicationResponse');
 const Team = require('./Team');
 const TeamMember = require('./TeamMember');
+const Admin = require('./Admin');
+const OauthAccessToken = require('./OauthAccessToken');
 
 module.exports = {
   db,
@@ -12,5 +14,7 @@ module.exports = {
   HackerApplication,
   ApplicationResponse,
   Team,
-  TeamMember
+  TeamMember,
+  OauthAccessToken,
+  Admin,
 };


### PR DESCRIPTION
This PR adds a new oauth API as a separate express app (mounted at `/hcapi`). Along with it comes oauth2 verification of tokens, and scripts to create new admin users and tokens.

There is also an API endpoint that we can use to verify if a particular token is valid for a particular user - which can be used as a check on startup that the login data is sane.

Readme is updated with some useful information on how to use this.

@jaredkhan could you review?
@moosichu once this lands, we can start building out business logic in the API.