### PR TITLE
Add CORS to our API

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "chalk": "^1.1.3",
     "client-sessions": "^0.7.0",
     "compression": "^1.6.1",
+    "cors": "^2.8.1",
     "country-list": "^1.0.0",
     "css-loader": "^0.21.0",
     "del": "^2.0.2",

--- a/src/js/server/hcapi/auth.js
+++ b/src/js/server/hcapi/auth.js
@@ -1,0 +1,34 @@
+const passport = require('passport');
+const BearerStrategy = require('passport-http-bearer');
+const cors = require('cors');
+const { Admin, OauthAccessToken } = require('js/server/models');
+
+passport.use(new BearerStrategy((token, done) => {
+  OauthAccessToken.getAdminFromTokenString(token)
+    .then((admin) => {
+      if (!admin) {
+        done(null, false);
+        return;
+      }
+
+      done(null, admin, { scope: 'all' });
+    })
+    .catch(error => done(error));
+}));
+
+exports.middleware = {
+  cors: cors({
+    origin: [
+      // Match an empty origin to allow external tools (like postman) to easily interact with the API
+      '',
+      // Match Heroku instances
+      /^https:\/\/hackcam(.*).herokuapp.com$/,
+      // Match *.hackcambridge.com
+      /^https:\/\/(.*\.)?hackcambridge\.com$/,
+      // Match local development environment
+      /^https?:\/\/localhost(:[0-9]+)?$/,
+    ],
+    credentials: true,
+  }),
+  bearer: passport.authenticate('bearer', { session: false }),
+};

--- a/src/js/server/hcapi/index.js
+++ b/src/js/server/hcapi/index.js
@@ -1,29 +1,16 @@
 const express = require('express');
 const bodyParser = require('body-parser');
-const passport = require('passport');
-const BearerStrategy = require('passport-http-bearer');
-const { Admin, OauthAccessToken } = require('js/server/models');
 const errors = require('./errors');
-
-passport.use(new BearerStrategy((token, done) => {
-  OauthAccessToken.getAdminFromTokenString(token)
-    .then((admin) => {
-      if (!admin) {
-        done(null, false);
-        return;
-      }
-
-      done(null, admin, { scope: 'all' });
-    })
-    .catch(error => done(error));
-}));
+const auth = require('./auth');
 
 /**
  * The hcapi is a separate express app to completely separate anything going on in our main website
  */
 const hcapi = express();
 
-hcapi.use(passport.authenticate('bearer', { session: false }));
+hcapi.options(auth.middleware.cors);
+hcapi.use(auth.middleware.cors);
+hcapi.use(auth.middleware.bearer);
 hcapi.use(bodyParser.json());
 
 // API endpoints


### PR DESCRIPTION
CORS is how the web handles requests from domains outside of the one where the website is found. Without implementing it, requests are locked down.

This adds the required functionality to support CORS so we can accept requests from our applications app (while keeping development tools available)

@jaredkhan could you review?