### PR TITLE
Fixed team members not displaying on the dashboard

### DIFF
--- a/src/views/apply/dashboard.html
+++ b/src/views/apply/dashboard.html
@@ -231,7 +231,7 @@
 
         {{ teamApplicationInfo.content }}
 
-        {% if teamApplicationStatus == statuses.teamApplication.complete %}
+        {% if teamApplicationStatus == statuses.teamApplication.COMPLETE %}
           {# Show a list of teammates #}
           <ul class="team-list">
             {% for hacker in teamMembers %}


### PR DESCRIPTION
Hooray for case sensitivity, and JavaScript’s lax object property getters!

@Pinpickle — could you review?