### PR TITLE
Add tickets endpoint to API

### DIFF
--- a/src/js/server/hcapi/index.js
+++ b/src/js/server/hcapi/index.js
@@ -19,6 +19,7 @@ hcapi.use('/admins', require('./admins'));
 hcapi.use('/applications', require('./applications'));
 hcapi.use('/stats', require('./stats'));
 hcapi.use('/criteria', require('./criteria'));
+hcapi.use('/tickets', require('./tickets'));
 
 // Errors
 hcapi.use(errors.middleware.notFound);

--- a/src/js/server/hcapi/tickets.js
+++ b/src/js/server/hcapi/tickets.js
@@ -1,0 +1,16 @@
+const { Router } = require('express');
+const { getTicketsWithApplicantInfo } = require('js/server/attendance/logic');
+
+const ticketsRouter = new Router();
+
+/**
+ * Gets all tickets with applicant info
+ */
+ticketsRouter.get('/', (req, res, next) => {
+  getTicketsWithApplicantInfo()
+    .then((tickets) => {
+      res.json(tickets);
+    }).catch(next);
+});
+
+module.exports = ticketsRouter;


### PR DESCRIPTION
This creates a tickets endpoint which contains valuable information for the logicians. I decided to make this logically separate from applications as convoluting the ticket exclusion with our current applications logic was pretty gnarly.

@jaredkhan or @varkor could you review?