### PR TITLE
Add team assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,25 @@ module.exports = ( (sortedApplications, n, inviteType) => {
   return sortedApplications.slice(0, n));
 });
 ```
+
 ## Closing applications
 
 You can control whether or not applications are open using the APPLICATION_OPEN_STATUS environment variable. This takes a value of either
 `open` or `closed`.
+
+## Team Allocations
+
+To send team allocations for ticketed hackers that have requested them, you must first suggest some:
+
+```
+npm run hc-script -- teams suggest teams.json
+```
+
+Then you can send them
+
+```
+npm run hc-script -- teams send teams.json
+```
 
 ## Build System
 

--- a/src/js/hc-scripts/index.js
+++ b/src/js/hc-scripts/index.js
@@ -10,6 +10,7 @@ yargs
   .command(require('./suggest-responses'))
   .command(require('./respond'))
   .command(require('./expire-invitations'))
+  .command(require('./teams'))
   .demand(1, 'Supply a command.')
   .help()
   .argv;

--- a/src/js/hc-scripts/teams/index.js
+++ b/src/js/hc-scripts/teams/index.js
@@ -1,0 +1,15 @@
+const { Admin } = require('js/server/models');
+const yargs = require('yargs');
+
+module.exports = {
+  command: 'teams',
+  desc: 'Operate on teams',
+  aliases: [],
+  builder(yargs) {
+    return yargs
+      .command(require('./suggest'))
+      .command(require('./send'))
+      .demand(1);
+  },
+  handler: () => { },
+};

--- a/src/js/hc-scripts/teams/send.js
+++ b/src/js/hc-scripts/teams/send.js
@@ -1,0 +1,36 @@
+const { sendTeamEmail } = require('js/server/attendance/team-logic');
+const fs = require('fs');
+const path = require('path');
+const { createHandler } = require('../utils');
+
+function createTeamQueue(teamsToProcess) {
+  // Defensive clone for mutating array
+  const teams = teamsToProcess.slice(0);
+
+  const processTeamQueue = () => {
+    if (teams.length === 0) {
+      return Promise.resolve();
+    }
+
+    const team = teams.pop();
+
+    return sendTeamEmail(team).then(() => processTeamQueue());
+  };
+
+  return {
+    process: processTeamQueue,
+  };
+}
+
+module.exports = {
+  command: 'send <inputfile>',
+  desc: 'Take any pending invitations that are too old and expire them',
+  aliases: [],
+  handler: createHandler(({ inputfile }) => {
+    const teams = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), inputfile)));
+
+    console.log(`Sending emails to ${teams.length} team${teams.length != 1 ? 's' : ''}`);
+
+    return createTeamQueue(teams).process();
+  }),
+};

--- a/src/js/hc-scripts/teams/suggest.js
+++ b/src/js/hc-scripts/teams/suggest.js
@@ -14,7 +14,7 @@ module.exports = {
   handler: createHandler(({ outputfile }) => 
     getSerializedTeamAssignments()
       .then((teams) => {
-        fs.writeFileSync(path.resolve(process.cwd(), outputfile), JSON.stringify(teams));
+        fs.writeFileSync(path.resolve(process.cwd(), outputfile), JSON.stringify(teams, null, 2));
         console.log(`Wrote ${teams.length} teams to ${outputfile}.`);
       })
   ),

--- a/src/js/hc-scripts/teams/suggest.js
+++ b/src/js/hc-scripts/teams/suggest.js
@@ -1,0 +1,21 @@
+const { getSerializedTeamAssignments } = require('js/server/attendance/team-logic');
+const yargs = require('yargs');
+const { createHandler } = require('../utils');
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+  command: 'suggest <outputfile>',
+  desc: 'Suggest allocations for teams',
+  aliases: [],
+  builder(yargs) {
+    return yargs;
+  },
+  handler: createHandler(({ outputfile }) => 
+    getSerializedTeamAssignments()
+      .then((teams) => {
+        fs.writeFileSync(path.resolve(process.cwd(), outputfile), JSON.stringify(teams));
+        console.log(`Wrote ${teams.length} teams to ${outputfile}.`);
+      })
+  ),
+};

--- a/src/js/server/attendance/email-templates.js
+++ b/src/js/server/attendance/email-templates.js
@@ -51,8 +51,8 @@ module.exports = {
       body: {
         name: 'Hackers',
         intro: [
-          'When you applied for Hack Cambridge you let us know that you wanted us to suggest you a team.',
-          'We\'ve done ths now, and here are everyone\'s details.',
+          'When you applied for Hack Cambridge, you let us know that you wanted us to suggest a team for you.',
+          'We\'ve done this now, and here are everyone\'s details:',
         ],
         dictionary: teamDictionary,
         outro: [

--- a/src/js/server/attendance/email-templates.js
+++ b/src/js/server/attendance/email-templates.js
@@ -1,5 +1,9 @@
 const { makeInstruction } = require('js/server/email');
 
+function teamKeyFromMember(member) {
+  return { [`${member.firstName} ${member.lastName}`]: `${member.email} (${member.slackName ? `Slack name: ${member.slackName}` : 'You haven\'t signed up for Slack yet!'})` };
+}
+
 module.exports = {
   newTicket({ name }) {
     return {
@@ -33,6 +37,29 @@ module.exports = {
           'We hope to see you apply for the next Hack Cambridge!'
         ],
         outro: 'If you have any questions, please reach out to us by visiting our website.',
+      }
+    }
+  },
+  teamAllocation({ team }) {
+    const teamDictionary = team.reduce((partialTeam, member) => 
+      Object.assign(partialTeam, teamKeyFromMember(member)),
+      { }
+    );
+
+    return {
+      subject: 'We\'ve put a team together for you for Hack Cambridge',
+      body: {
+        name: 'Hackers',
+        intro: [
+          'When you applied for Hack Cambridge you let us know that you wanted us to suggest you a team.',
+          'We\'ve done ths now, and here are everyone\'s details.',
+        ],
+        dictionary: teamDictionary,
+        outro: [
+          'Start the conversation by hitting reply all! Please exclude us from that email.',
+          'This is just a suggestion, it is not binding, you can enter whatever team you like at Hack Cambridge.',
+          'If you have any questions, please reach out to us by visiting our website.',
+        ]
       }
     }
   }

--- a/src/js/server/attendance/team-logic.js
+++ b/src/js/server/attendance/team-logic.js
@@ -25,21 +25,18 @@ function getAllApplicationsWantingTeams() {
   });
 }
 
-function applicationDevelopmentComparison(applicationA, applicationB) {
-  for (role of ROLE_ORDERING) {
-    const roleInA = applicationA.developmentRoles.includes(role);
-    const roleInB = applicationB.developmentRoles.includes(role);
-
-    if (roleInA) {
-      return roleInB ? 0 : -1;
-    }
-
-    if (roleInB) {
-      return 1;
+function getHighestPriorityRoleIndex(application) {
+  for (let roleIndex in ROLE_ORDERING) {
+    if (application.developmentRoles.includes(ROLE_ORDERING[roleIndex])) {
+      return roleIndex;
     }
   }
 
-  return 0;
+  return ROLE_ORDERING.length;
+}
+
+function applicationDevelopmentComparison(applicationA, applicationB) {
+  return getHighestPriorityRoleIndex(applicationA) - getHighestPriorityRoleIndex(applicationB);
 }
 
 function createEmptyTeams(applications) {

--- a/src/js/server/attendance/team-logic.js
+++ b/src/js/server/attendance/team-logic.js
@@ -1,0 +1,125 @@
+const { HackerApplication, ApplicationTicket, Hacker } = require('js/server/models');
+const slack = require('js/server/slack');
+const { sendEmail } = require('js/server/email');
+
+const emailTemplates = require('./email-templates');
+
+const ROLE_ORDERING = ['development', 'design', 'product_management', 'unknown'];
+const TARGET_TEAM_SIZE = 4;
+
+function getAllApplicationsWantingTeams() {
+  return HackerApplication.findAll({
+    where: {
+      wantsTeam: true,
+    },
+    include: [
+      {
+        model: ApplicationTicket,
+        required: true,
+      },
+      {
+        model: Hacker,
+        required: true,
+      },
+    ],
+  });
+}
+
+function applicationDevelopmentComparison(applicationA, applicationB) {
+  for (role of ROLE_ORDERING) {
+    const roleInA = applicationA.developmentRoles.includes(role);
+    const roleInB = applicationB.developmentRoles.includes(role);
+
+    if (roleInA) {
+      return roleInB ? 0 : -1;
+    }
+
+    if (roleInB) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+function createEmptyTeams(applications) {
+  const teamCount = Math.ceil(applications.length / TARGET_TEAM_SIZE);
+
+  return new Array(teamCount).fill(0).map(() => []);
+}
+
+function assignApplicationsToTeams(applications) {
+  const applicationsToAssign = applications.slice(0);
+  let teamIndex = 0;
+  const teams = createEmptyTeams(applicationsToAssign);
+
+  applications.forEach((application) => {
+    teams[teamIndex % teams.length].push(application);
+    teamIndex += 1;
+  });
+  
+  return teams;
+}
+
+function getApplicationsSortedByRole(unsortedApplications) {
+  const sortedApplications = unsortedApplications.slice(0);
+
+  sortedApplications.sort(applicationDevelopmentComparison);
+
+  return sortedApplications;
+}
+
+function createTeamAssignments() {
+  return getAllApplicationsWantingTeams()
+    .then(getApplicationsSortedByRole)
+    .then(assignApplicationsToTeams);
+}
+
+function getSlackNameForEmail(slackUsers, email) {
+  for (user of slackUsers) {
+    if (user.profile.email === email) {
+      return user.name;
+    }
+  }
+
+  return null;
+}
+
+function serializeTeams(teams, slackUsers) {
+  return teams.map(team => team.map(
+    application => ({
+      applicationId: application.id,
+      hackerId: application.hacker.id,
+      ticketId: application.applicationTicket.id,
+      roles: application.developmentRoles,
+      email: application.hacker.email,
+      firstName: application.hacker.firstName,
+      lastName: application.hacker.lastName,
+      slackName: getSlackNameForEmail(slackUsers, application.hacker.email),
+    })
+  ));
+}
+
+function sendTeamEmail(team) {
+  const teamIdentifier = team.map(member => member.hackerId).join(', ');
+  console.log(`Sending team email to ${teamIdentifier}`)
+
+  return sendEmail({
+    to: team.map(member => member.email),
+    contents: emailTemplates.teamAllocation({ team }),
+  }).catch((error) => {
+    console.error(`Sending team email to ${teamIdentifier} failed: `, error);
+  });
+}
+
+function getSerializedTeamAssignments() {
+  return Promise.all([
+    createTeamAssignments(),
+    slack.getUsers(),
+  ]).then(([teams, slackUsers]) => serializeTeams(teams, slackUsers));
+}
+
+module.exports = {
+  getSerializedTeamAssignments,
+  sendTeamEmail,
+};

--- a/src/js/server/slack.js
+++ b/src/js/server/slack.js
@@ -53,8 +53,23 @@ function inviteUser(email, firstName, lastName) {
   })
 }
 
+/**
+ * Gets all Slack users
+ */
+function getUsers() {
+  return makeSlackApiCall('users.list', { })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(response.error);
+      }
+
+      return response.members;
+    });
+}
+
 module.exports = {
   SlackApiError,
   makeSlackApiCall,
   inviteUser,
+  getUsers,
 };


### PR DESCRIPTION
This adds a new script command, `teams`, with sub-commands `suggest` and `send` for suggesting and sending team allocations respectively.

This is what the email looks like:

![image](https://cloud.githubusercontent.com/assets/3238878/21866672/0a4e861e-d8b0-11e6-8f7e-6d75f6dc5afa.png)

@jaredkhan could you review?
