### PR TITLE
Make rough event page

### DIFF
--- a/src/js/server/index.js
+++ b/src/js/server/index.js
@@ -99,6 +99,16 @@ app.get('/pay', function (req, res) {
   });
 });
 
+app.get('/event', function (req, res) {
+  res.render('event.html', {
+    title: 'Hack Cambridge Recurse',
+    workshops: utils.loadResource('workshops'),
+    prizes: utils.loadResource('prizes'),
+    schedule: utils.loadResource('schedule'),
+    apis: utils.loadResource('apis')
+  });
+});
+
 app.get('/volunteers', (req, res) => {
   res.redirect(302, 'https://goo.gl/forms/2jHTyCKiXQgGR6Jy2');
 })

--- a/src/js/server/utils.js
+++ b/src/js/server/utils.js
@@ -118,8 +118,8 @@ exports.loadResource = function loadResource(resourceName) {
       case 'schedule':
         timeProperties(loadedResource, ['time']);
         loadedResource = {
-          saturday: loadedResource.filter((event) => event.time.date() == 30),
-          sunday: loadedResource.filter((event) => event.time.date() == 31)
+          saturday: loadedResource.filter((event) => event.time.date() == 28),
+          sunday: loadedResource.filter((event) => event.time.date() == 29)
         };
         break;
       case 'dashboard':
@@ -137,8 +137,8 @@ exports.loadMarkdown = function loadMarkdown(markdownName) {
   if ((!loadedMarkdowns[markdownName]) || (app.settings.env == 'development')) {
     var loadedMarkdown = nunjucks.runtime.markSafe(
       markdown.render(fs.readFileSync(exports.resolvePath(
-        `src/resources/${markdownName}.md`, 'utf8'
-      )))
+        `src/resources/${markdownName}.md`), 'utf8'
+      ))
     );
     loadedMarkdowns[markdownName] = loadedMarkdown;
   }

--- a/src/resources/info.md
+++ b/src/resources/info.md
@@ -1,19 +1,18 @@
 ## Getting to the Corn Exchange
 
 By now you should know how you're getting to Cambridge be it by train, coach, car or horse.
-The Cambridge Corn exchange is about a 20 minute walk from the train station. For details on
-directions, parking and cycling please see the [directions page for the Corn Exchange](https://www.cambridgelivetrust.co.uk/cornex/venue-info/directions-and-parking-0){target="_blank"}.
-We have a [map](#map) just below on this page which will give a little more context.
+The Cambridge Corn exchange is about a 20 minute walk from the train station. For more details
+you can check [your dashboard](/apply/dashboard) or see [directions page on the Corn Exchange website](https://www.cambridgelivetrust.co.uk/cornex/venue-info/directions-and-parking-0){target="_blank"}.
+
+<div class="event-tba">
+
+## The Guildhall
 
 ## Hardware
 
-The hardware table just in front of the stage will have all of the bits and pieces
-that you need for a hardware hack while it is open. Check out [hardware.mlh.io](hardware.mlh.io){target="_blank"} for details on what you can get.
-
 ## Food &amp; Snacks
 
-Snacks are available regularly at the back of the hall, please help yourself. You can find hot drinks upstairs on the mezzanine on the right side. Meals are served at meal
-times throughout the event, and will be announced to make sure you get fed.
+</div>
 
 ## Emergencies
 
@@ -21,27 +20,11 @@ In the event of an emergency, please note the UK emergency phone number, **999**
 If you need to leave the building (e.g. for a fire), please leave the building promptly
 through the nearest fire exit. Do not pick up your laptop or hardware hacks or swag.
 
-## UIS Workshops
-
-Our workshops are held in the UIS rooms, where the WiFi system is different. Before you go, please get a ticket number and password from our [WiFi page](/wifi) (you will need your Hack Cambridge ticket reference). Once at a workshop, you will need to connect to UniOfCam and enter the details you obtained from the WiFi page.
-
 ## Submitting Your Hack
 
 We are using [Devpost](http://devpost.com) for hack submissions. Never used it before? It's an online platform for sharing your projects.
 
-- All hacks must be submitted before hacking ends at 12:00:00pm
+- All hacks must be submitted before hacking ends at 12:45:00pm
 - You must submit all relevant source code for your hack
 
-**All team members** need to do the following:
-
-1. Make sure all of your team members are registered for Devpost and you know their usernames.
-2. Head over to the [Hack Cambridge Devpost](http://hackcambridge.devpost.com/), click on "Register for this hackathon".
-
-Then **just one team member** needs to:
-
-1. On the Devpost page, click "Enter a submission". Create your new project for the hackathon.
-    - Be nice and descriptive and upload pretty pictures
-    - Provide access to relevant source code in some way (GitHub is the easiest way to do this)
-    - Add all of your team members to the project
-2. In the next step, **choose all of the prizes** you want to be eligible for. If you've used someone's API or have fit a certain theme, make sure to do this or you won't be considered.
-3. Submit! We'll handle the rest.
+We'll be posting more details on this closer to the time.

--- a/src/resources/schedule.yml
+++ b/src/resources/schedule.yml
@@ -1,33 +1,51 @@
 schedule:
   - event: Registration Opens
-    time: 2016-01-30 9:00:00
+    time: 2017-01-28 9:00:00
   - event: Pitching Session
-    time: 2016-01-30 9:00:00
+    time: 2017-01-28 9:00:00
   - event: Opening Ceremony
-    time: 2016-01-30 11:00:00
+    time: 2017-01-28 12:00:00
   - event: Hacking Starts
-    time: 2016-01-30 12:00:00
+    time: 2017-01-28 12:45:00
     class: emphasis
   - event: Lunch
-    time: 2016-01-30 12:00:00
+    time: 2017-01-28 13:00:00
+  - event: API Demos
+    time: 2017-01-28 14:00:00
+    class: small
+  - event: Waffles in Foyer
+    time: 2017-01-28 15:00:00
+    class: small
   - event: Workshops
-    time: 2016-01-30 13:00:00
+    time: 2017-01-28 15:15:00
+    class: small
   - event: Dinner
-    time: 2016-01-30 18:00:00
+    time: 2017-01-28 19:00:00
   - event: Bloomberg !Light Competition
-    time: 2016-01-30 20:00:00
+    time: 2017-01-28 20:00:00
+  - event: Sleeping Area Opens
+    time: 2017-01-28 22:00:00
+    class: small
 
   # Suday
-  - event: Midnight
-    time: 2016-01-31 00:00:00
+  - event: Midnight Snack
+    time: 2017-01-29 00:00:00
   - event: Breakfast
-    time: 2016-01-31 07:00:00
+    time: 2017-01-29 07:00:00
   - event: Hacking Ends
-    time: 2016-01-31 12:00:00
+    time: 2017-01-29 12:45:00
     class: emphasis
   - event: Hack Expo
-    time: 2016-01-31 13:00:00
+    time: 2017-01-29 13:30:00
+  - event: Finalists Announced
+    time: 2017-01-29 15:00:00
+    class: small
+  - event: Finalist Presentations
+    time: 2017-01-29 15:15:00
   - event: Closing Ceremony
-    time: 2016-01-31 16:15:00
+    time: 2017-01-29 17:00:00
   - event: Hack Cambridge Concludes
-    time: 2016-01-31 17:00:00
+    time: 2017-01-29 17:30:00
+  - event: Venue Closes
+    time: 2017-01-29 18:00:00
+    class: small

--- a/src/resources/workshops.yml
+++ b/src/resources/workshops.yml
@@ -1,130 +1,129 @@
-workshops:
-
-  - name: Give your app an unfair advantage with HPE Haven OnDemand APIs
-    description: |
-      With more than 60 powerful and easy to use APIs, HPE Haven OnDemand can crawl, index and analyze data from file systems and the web.
-      It can analyze and extract insights from text, audio, video, and image files, or be used to build prediction models and recommendation engines.
-      By combining APIs you'll be able to create powerful data transformation and enrichment workflows.
-
-      Join us for a demo, followed by Q&A.
-
-      Speaker: Tyler Nappy, Developer Evangelist
-      Follow Tyler on Twitter [@tylernappy](https://twitter.com/tylernappy)
-    time: 2016-01-30 13:00:00
-    duration: 30 # In minutes
-    location: Cockcroft Lecture Theatre
-
-  - name: How Mendeley can manage your course load
-    description: |
-      What is Mendeley and why you will care in the future? For all you researchers and future Masters and PhDs, Mendeley will help clear the
-      busywork from your course load. Our tools are designed to help you discover new research, organise your reference work and connect with
-      experts and other like-minded people. Come along if you want to hear more about how Mendeley will help you in your future studies.
-    time: 2016-01-30 13:10:00
-    duration: 10
-    location: Phoenix
-
-  - name: Beaker in action
-    description: |
-      Scott Draves is an award-winning software artist, VJ, and a pioneer of the open source movement.
-      His clients and exhibitions range from the likes of MoMA.org, LACMA, Google, and the Adler Planetarium to Skrillex.
-      He has a PhD in Computer Science from Carnegie Mellon and a BS in Math from Brown. Draves is currently employed as the PM and developer
-      of [the Beaker Notebook](http://beakernotebook.com/) for Two Sigma Open Source.
-
-      This talk will motivate the design, review the architecture, and include a live demo of Beaker in action.
-    time: 2016-01-30 13:20:00
-    duration: 30
-    location: Titan
-
-  - name: Hacking with Mailjet
-    description: |
-      Email is not dead! But it is changing.
-      Leverage the #1 communication channel to discuss with your users, notify them or build original hacks to innovate.
-      We'll see how developers use email in a creative way in their apps and startups.
-      We'll also cover how easy it is to send, monitor the emails you send with rich analytics, and last but not least, parse inbound emails to extract data with the Mailjet APIs.
-    time: 2016-01-30 13:30:00
-    duration: 10
-    location: Phoenix
-
-  - name: Metaswitch on Communicating in the Cloud
-    description: |
-      Global communications networks are undergoing fundamental change.  Historically built on specialised, dedicated hardware, today’s
-      communication services are delivered on standard commodity computing hardware … with all the intelligence delivered in software.
-
-      This technology revolution is enabling dramatically faster innovation and has created startling potential for new services to capture 10s
-      or 100s of millions of users rapidly.
-
-      We will analyse the key technological changes that are driving this revolution, illustrate some of the complex programming challenges
-      that arise, and discuss the opportunities for software developers in this domain.
-    time: 2016-01-30 16:30:00
-    duration: 30
-    location: Titan
-
-  - name: 3 Google Cloud Platform Tools
-    description: |
-      Our API challenge is open on any piece of Google Cloud Platform, but some tools make more sense at an event like a hackathon than others.
-      We'll recommend 3 tools that can help you get your ideas out there as fast as you can this weekend.
-    time: 2016-01-30 13:50:00
-    duration: 10
-    location: Phoenix
-
-  - name: Cantab on FinTech
-    description: |
-      Finance has been a Big Data arena for decades, long before the term FinTech was coined. We will review the opportunities for programmers
-      in hedge funds and investment banks. As time permits, we will drill down on interesting implementation details involving time series data.
-      There will be some visualisations of how one trades billions of dollars a day, and how one copes with millisecond updates to the data that
-      feeds ‘black box’ trading models.
-    time: 2016-01-30 14:00:00
-    duration: 30
-    location: Titan
-
-  - name: What can you build with Skyscanner’s API in 24 hours?
-    description: |
-      Started in 2003, Skyscanner is Scotland’s first unicorn technology startup.
-      Over the years we’ve grown into one of the world’s top travel meta-search engines with more than 750 travel partnerships and over 40 million unique monthly visitors.
-      Our API is free to use for individuals and startups alike to add travel search functionality to existing products, or build fully-fledged travel search products.
-      What could you build in 24 hours?
-
-      Speakers: Iain McDonald and Matt Smith
-    time: 2016-01-30 14:10:00
-    duration: 10
-    location: Phoenix
-
-  - name: Hardware Security Modules – By Thales e-Security
-    description: |
-      This talk will describe what Hardware Security Modules are, what they are good for, why they are deployed, and some of their limitations.
-      The talk will focus on the nShield line of general purpose HSMs. We shall describe the architecture, security mechanisms including key
-      protection and policies, and discuss example applications.
-
-      Speakers: Clara Juanes Vallejo, Business Transformation Manager, and Robert Rainbird, Lead Engineer.
-    time: 2016-01-30 15:00:00
-    duration: 30
-    location: Cockcroft Lecture Theatre
-
-  - name: Workshop by Improbable
-    description: |
-      TBA
-    time: 2016-01-30 15:20:00
-    duration: 30
-    location: Titan
-
-  - name: Workshop by G-Research
-    description: |
-      TBA
-    time: 2016-01-30 16:00:00
-    duration: 30
-    location: Cockcroft Lecture Theatre
-
-  - name: Winning at APIs - Getting started working with APIs
-    description: |
-      Manthan Dave from Capital One will give an overview of how APIs work, what they’re used for and how can they be used securely. An understanding
-      and consumption of APIs is a critical skill, this is a talk not to be missed!
-    time: 2016-01-30 14:30:00
-    duration: 10
-    location: Cockroft Lecture Theatre
-  - name: Bloomberg workshop
-    description: |
-      Bloomberg are giving an awesome workshop. Details tbc...
-    time: 2016-01-30 17:00:00
-    duration: 30
-    location: Cockroft Lecture Theatre
-
+workshops: [ ]
+#   - name: Give your app an unfair advantage with HPE Haven OnDemand APIs
+#     description: |
+#       With more than 60 powerful and easy to use APIs, HPE Haven OnDemand can crawl, index and analyze data from file systems and the web.
+#       It can analyze and extract insights from text, audio, video, and image files, or be used to build prediction models and recommendation engines.
+#       By combining APIs you'll be able to create powerful data transformation and enrichment workflows.
+# 
+#       Join us for a demo, followed by Q&A.
+# 
+#       Speaker: Tyler Nappy, Developer Evangelist
+#       Follow Tyler on Twitter [@tylernappy](https://twitter.com/tylernappy)
+#     time: 2016-01-30 13:00:00
+#     duration: 30 # In minutes
+#     location: Cockcroft Lecture Theatre
+# 
+#   - name: How Mendeley can manage your course load
+#     description: |
+#       What is Mendeley and why you will care in the future? For all you researchers and future Masters and PhDs, Mendeley will help clear the
+#       busywork from your course load. Our tools are designed to help you discover new research, organise your reference work and connect with
+#       experts and other like-minded people. Come along if you want to hear more about how Mendeley will help you in your future studies.
+#     time: 2016-01-30 13:10:00
+#     duration: 10
+#     location: Phoenix
+# 
+#   - name: Beaker in action
+#     description: |
+#       Scott Draves is an award-winning software artist, VJ, and a pioneer of the open source movement.
+#       His clients and exhibitions range from the likes of MoMA.org, LACMA, Google, and the Adler Planetarium to Skrillex.
+#       He has a PhD in Computer Science from Carnegie Mellon and a BS in Math from Brown. Draves is currently employed as the PM and developer
+#       of [the Beaker Notebook](http://beakernotebook.com/) for Two Sigma Open Source.
+# 
+#       This talk will motivate the design, review the architecture, and include a live demo of Beaker in action.
+#     time: 2016-01-30 13:20:00
+#     duration: 30
+#     location: Titan
+# 
+#   - name: Hacking with Mailjet
+#     description: |
+#       Email is not dead! But it is changing.
+#       Leverage the #1 communication channel to discuss with your users, notify them or build original hacks to innovate.
+#       We'll see how developers use email in a creative way in their apps and startups.
+#       We'll also cover how easy it is to send, monitor the emails you send with rich analytics, and last but not least, parse inbound emails to extract data with the Mailjet APIs.
+#     time: 2016-01-30 13:30:00
+#     duration: 10
+#     location: Phoenix
+# 
+#   - name: Metaswitch on Communicating in the Cloud
+#     description: |
+#       Global communications networks are undergoing fundamental change.  Historically built on specialised, dedicated hardware, today’s
+#       communication services are delivered on standard commodity computing hardware … with all the intelligence delivered in software.
+# 
+#       This technology revolution is enabling dramatically faster innovation and has created startling potential for new services to capture 10s
+#       or 100s of millions of users rapidly.
+# 
+#       We will analyse the key technological changes that are driving this revolution, illustrate some of the complex programming challenges
+#       that arise, and discuss the opportunities for software developers in this domain.
+#     time: 2016-01-30 16:30:00
+#     duration: 30
+#     location: Titan
+# 
+#   - name: 3 Google Cloud Platform Tools
+#     description: |
+#       Our API challenge is open on any piece of Google Cloud Platform, but some tools make more sense at an event like a hackathon than others.
+#       We'll recommend 3 tools that can help you get your ideas out there as fast as you can this weekend.
+#     time: 2016-01-30 13:50:00
+#     duration: 10
+#     location: Phoenix
+# 
+#   - name: Cantab on FinTech
+#     description: |
+#       Finance has been a Big Data arena for decades, long before the term FinTech was coined. We will review the opportunities for programmers
+#       in hedge funds and investment banks. As time permits, we will drill down on interesting implementation details involving time series data.
+#       There will be some visualisations of how one trades billions of dollars a day, and how one copes with millisecond updates to the data that
+#       feeds ‘black box’ trading models.
+#     time: 2016-01-30 14:00:00
+#     duration: 30
+#     location: Titan
+# 
+#   - name: What can you build with Skyscanner’s API in 24 hours?
+#     description: |
+#       Started in 2003, Skyscanner is Scotland’s first unicorn technology startup.
+#       Over the years we’ve grown into one of the world’s top travel meta-search engines with more than 750 travel partnerships and over 40 million unique monthly visitors.
+#       Our API is free to use for individuals and startups alike to add travel search functionality to existing products, or build fully-fledged travel search products.
+#       What could you build in 24 hours?
+# 
+#       Speakers: Iain McDonald and Matt Smith
+#     time: 2016-01-30 14:10:00
+#     duration: 10
+#     location: Phoenix
+# 
+#   - name: Hardware Security Modules – By Thales e-Security
+#     description: |
+#       This talk will describe what Hardware Security Modules are, what they are good for, why they are deployed, and some of their limitations.
+#       The talk will focus on the nShield line of general purpose HSMs. We shall describe the architecture, security mechanisms including key
+#       protection and policies, and discuss example applications.
+# 
+#       Speakers: Clara Juanes Vallejo, Business Transformation Manager, and Robert Rainbird, Lead Engineer.
+#     time: 2016-01-30 15:00:00
+#     duration: 30
+#     location: Cockcroft Lecture Theatre
+# 
+#   - name: Workshop by Improbable
+#     description: |
+#       TBA
+#     time: 2016-01-30 15:20:00
+#     duration: 30
+#     location: Titan
+# 
+#   - name: Workshop by G-Research
+#     description: |
+#       TBA
+#     time: 2016-01-30 16:00:00
+#     duration: 30
+#     location: Cockcroft Lecture Theatre
+# 
+#   - name: Winning at APIs - Getting started working with APIs
+#     description: |
+#       Manthan Dave from Capital One will give an overview of how APIs work, what they’re used for and how can they be used securely. An understanding
+#       and consumption of APIs is a critical skill, this is a talk not to be missed!
+#     time: 2016-01-30 14:30:00
+#     duration: 10
+#     location: Cockroft Lecture Theatre
+#   - name: Bloomberg workshop
+#     description: |
+#       Bloomberg are giving an awesome workshop. Details tbc...
+#     time: 2016-01-30 17:00:00
+#     duration: 30
+#     location: Cockroft Lecture Theatre
+# 

--- a/src/styles/event.styl
+++ b/src/styles/event.styl
@@ -1,0 +1,397 @@
+/* ==========================================================================
+   Event Page
+   ========================================================================== */
+
+.event-tba {
+  opacity: 0.3;
+  user-select: none;
+  cursor: normal;
+}
+
+/* Intro
+   ========================================================================== */
+
+ .section-event-intro {
+   display: flex;
+   flex-direction: column;
+   justify-content: center;
+   align-items: left;
+   position: relative;
+
+   box-sizing: border-box;
+   width: 100%;
+   min-height: "calc(100vh - %s)" % (($punit * 6));
+   text-align: center;
+   padding: ($punit * 3) 0;
+
+   dark-background();
+   color: #fff;
+ }
+
+ .event-timer-intro {
+   font-size: 1.2em;
+   color: lighten($colorSecondary, 20%);
+ }
+
+ .event-countdown {
+   .countdown-digit {
+     width: 1.25ex;
+     text-align: center;
+     display: inline-block;
+   }
+ }
+
+ .event-logo {
+   max-width: 100%;
+   width: 400px;
+   margin-bottom: $punit;
+ }
+
+.event-nav {
+  margin: 10px -10px;
+
+  .event-nav-button {
+    color: #fff;
+    font-size: 1.2em;
+    padding: 20px 10px;
+    transition: background-color 0.2s;
+    display: inline-block;
+
+    &:hover {
+      text-decoration: none;
+      background-color: alpha($colorSecondary, 8%);
+    }
+
+    &:active {
+      background-color: alpha($colorSecondary, 15%);
+    }
+  }
+}
+
+@media (min-width: 900px) {
+  .event-timer-intro {
+    position: absolute;
+    font-weight: 100;
+    right: 100px;
+    font-size: 2em;
+    height: 50px;
+    line-height: 50px;
+    top: 50%;
+    margin-top: -25px;
+  }
+}
+
+@media (min-width: 1100px) {
+  .event-timer-intro {
+    right: 200px;
+    font-size: 3em;
+  }
+}
+
+/* Info
+   ========================================================================== */
+
+.section-event-info {
+  padding: ($punit * 4) 0;
+  main-background();
+}
+
+/* Prizes
+   ========================================================================== */
+
+.section-event-prizes {
+  padding: $punit * 3 0;
+  main-background();
+}
+
+/* APIs
+   ========================================================================== */
+
+ .section-event-apis {
+   padding: $punit * 3 0;
+   main-background();
+ }
+
+/* Map
+   ========================================================================== */
+
+.section-event-map {
+  dark-background();
+  padding: $punit;
+
+  color: #fff;
+}
+
+@media (min-width: 600px) {
+  .section-event-map {
+    padding: $punit * 2;
+  }
+}
+
+/* APIs
+   ========================================================================== */
+
+.event-api {
+
+  &:nth-child(2n + 1) {
+    background: rgba(0, 0, 0, 0.04);
+    border-radius: 5px;
+    margin-left: -10px;
+    margin-right: -10px;
+    padding: 10px;
+    margin-bottom: $punit;
+  }
+}
+
+/* Schedule
+   ========================================================================== */
+
+.section-event-timetable {
+  dark-background();
+  color: #fff;
+  padding: ($punit * 4) 0;
+}
+
+.event-timetable-schedule {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 40px;
+
+  h3 {
+    color: #fff;
+    margin-right: $punit;
+    border-bottom: 1px solid #fff;
+    padding-bottom: ($punit / 2);
+  }
+}
+
+.event-timetable-schedule-day {
+  padding-left: 50px;
+  box-sizing: border-box;
+  margin-bottom: $punit;
+}
+
+.event-timetable-schedule-item {
+  position: relative;
+  margin: 20px 0;
+
+  &-name {
+    font-size: 1.3em;
+    opacity: 0.9;
+  }
+
+  &-time {
+    position: absolute;
+    width: 50px;
+    padding-right: 10px;
+    box-sizing: border-box;
+    left: -50px;
+    top: 6px;
+
+    text-align: right;
+    color: darken($colorPrimary, 50%);
+    letter-spacing: 0.05em;
+    font-size: 0.9em;
+  }
+
+  &-emphasis &-time {
+    color: #fff;
+  }
+
+  &-emphasis &-name {
+    font-weight: bold;
+    opacity: 1;
+  }
+
+  &-small {
+    margin: 10px 0;
+  }
+
+  &-small &-name {
+    font-size: 1em;
+    opacity: 0.8;
+  }
+
+  &-small &-time {
+    top: 1px;
+  }
+}
+
+.event-timetable-workshops {
+  border-left: 2px solid darken($colorSecondary, 30%);
+  padding-left: $punit;
+  margin-left: 40px;
+}
+
+.event-workshop-time {
+  position: absolute;
+  left: (~$punit - 50px);
+  padding-right: 10px;
+  top: 2px;
+  box-sizing: border-box;
+  width: 50px;
+  text-align: right;
+  color: lighten($colorSecondary, 20%);
+  letter-spacing: 0.05em;
+  font-size: 0.9em;
+
+  &::before {
+    position: absolute;
+    content: ' ';
+    display: block;
+    width: 13px;
+    border-bottom: 2px solid darken($colorSecondary, 30%);
+    right: -12px;
+    top: 11px;
+  }
+}
+
+.event-workshop-decorator {
+  text-transform: uppercase;
+  font-size: 0.8em;
+  font-weight: bold;
+  opacity: 0.5;
+  margin: 5px 0;
+  line-height: 1;
+}
+
+.event-workshop-location {
+  margin-top: -15px;
+  color: $colorSecondary;
+  letter-spacing: 0.05em;
+  font-size: 0.9em;
+}
+
+.event-workshop-description {
+  color: lighten($colorSecondary, 50%);
+}
+
+.event-workshop {
+  margin-bottom: ($punit * 2);
+  position: relative;
+}
+
+@media (min-width: 600px) {
+  .event-timetable-schedule {
+    flex-direction: row;
+  }
+
+  .event-timetable-schedule-day {
+    width: 50%;
+  }
+}
+
+@media (min-width: 900px) {
+  .event-timetable-workshops {
+    margin-left: 0;
+  }
+
+  .event-timetable-schedule {
+    margin-left: -50px;
+  }
+}
+
+/* Prizes
+   ========================================================================== */
+
+.section-event-prizes {
+  .content-wrapper {
+    width: 1000px
+  }
+}
+
+.event-prize-container {
+  margin: 0 (~$punit / 2);
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: justify;
+  margin-bottom: $punit;
+}
+
+.event-prize {
+  width: 100%;
+  box-sizing: border-box;
+  padding: ($punit / 2);
+  flex: 0 1 100%;
+  display: flex;
+  flex-direction: column;
+
+  h3 {
+    font-size: 1.5em;
+  }
+}
+
+.event-prize-decorate {
+  decorate($col) {
+    .event-prize-inner {
+      border-radius: 10px;
+      padding: 15px;
+      background: radial-gradient(circle at top center, $col, darken($col, 5));
+
+      color: #fff;
+      box-shadow: 0 0 8px rgba(0, 0, 0, 0.01), 0 2px 2px rgba(0, 0, 0, 0.1);
+    }
+  }
+
+  &-first {
+    decorate(#F7C717);
+  }
+
+  &-second {
+    decorate(#ACAFAF);
+  }
+
+  &-third {
+    decorate(#B29872);
+  }
+
+  &-pc {
+    decorate(#C15BDB);
+  }
+
+  &-security {
+    decorate(#00BADF)
+  }
+
+  &-gaming {
+    decorate(#FF2B00)
+  }
+
+  &-machine {
+    decorate(#031022)
+  }
+
+  &-hardware {
+    decorate(#33cc33)
+  }
+}
+
+.event-prize-inner {
+  flex: 1 0 auto;
+}
+
+.event-prize-content {
+  margin-top: -10px;
+  letter-spacing: 0.05em;
+  font-size: 0.9em;
+  opacity: 0.8;
+}
+
+@media (min-width: 600px) {
+  .event-prize {
+    width: 50%;
+    flex-basis: 50%;
+  }
+}
+
+@media (min-width: 800px) {
+  .event-prize-container {
+    margin-left: ~$punit;
+    margin-right: ~$punit;
+  }
+
+  .event-prize {
+    padding: $punit;
+  }
+}

--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -8,4 +8,5 @@
 @import 'home';
 @import 'apply';
 @import 'elements';
+@import 'event';
 @import 'payment';

--- a/src/views/event.html
+++ b/src/views/event.html
@@ -1,0 +1,125 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="section-event-intro">
+  <div class="content-wrapper">
+    <img class="event-logo" src="{{ asset('images/logos/hc2017-logo-full-light.svg') }}" alt="Hack Cambridge" />
+    <p>2017 Event Guide<br />This page is a work in progress and will be updated as we get closer to the event.</p>
+
+    <div class="event-countdown event-timer-intro"></div>
+
+    <nav class="event-nav">
+      <a class="event-nav-button" href="#info">Info</a>
+      <a class="event-nav-button" href="#map">Map</a>
+      <a class="event-nav-button" href="#apis">APIs</a>
+      <a class="event-nav-button" href="#schedule">Schedule</a>
+      <a class="event-nav-button" href="#prizes">Prizes</a>
+    </nav>
+  </div>
+</section>
+
+<section class="section-event-info" id="info">
+  <div class="content-wrapper">
+    <h1 class="grand-heading">General Information</h1>
+    {{ markdownResource('info') }}
+  </div>
+</section>
+
+<section class="section-event-map" id="map">
+  <div class="content-wrapper-center event-tba">
+    <h1>Event map coming soon</h1>
+  </div>
+</section>
+
+<section class="section-event-apis" id="apis">
+  <div class="content-wrapper event-tba">
+    <h2 class="grand-heading">APIs &amp; Challenges</h2>
+    <p>APIs and challenges will be announced soon!</p>
+    {# {% for api in apis %}
+      <div class="event-api">
+        <h3>{{ api.name }}</h3>
+        <div class="event-api-description">
+          {{ api.description }}
+        </div>
+      </div>
+    {% endfor %} #}
+</section>
+
+<section class="section-event-timetable" id="schedule">
+  <div class="content-wrapper">
+    <h2 class="grand-heading">Schedule</h2>
+
+    {% macro render_schedule(day) %}
+      <div class="event-timetable-schedule-day event-timetable-schedule-{{ day }}">
+        <h3>{{ day | title }}</h3>
+        {% for event in schedule[day] %}
+        <div class="event-timetable-schedule-item{% if event.class %} event-timetable-schedule-item-{{ event.class }}{% endif %}">
+          <div class="event-timetable-schedule-item-time">{{ event.time.format('HH:mm') }}</div>
+          <div class="event-timetable-schedule-item-name">{{ event.event }}</div>
+        </div>
+        {% endfor %}
+      </div>
+    {% endmacro %}
+
+    <div class="event-timetable-schedule">
+      {{ render_schedule('saturday') }}
+      {{ render_schedule('sunday') }}
+    </div>
+
+    <div class="event-tba">
+      <h2 class="grand-heading">Workshops &amp; API Demos</h2>
+      <p>Information on workshops and API prizes will be announced soon.</p>
+    </div>
+    {# Workshops #}
+    {# General timetable #}
+    {# <div class="event-timetable-workshops">
+      {% for workshop in workshops %}
+        <div class="event-workshop">
+          <h3>{{ workshop.name }}</h3>
+          <p class="event-workshop-location">Location: {{ workshop.location }}</p>
+          <div class="event-workshop-time">
+            {% if not workshop.time.isValid() %}
+              TBA
+            {% else %}
+              {{ workshop.time.format('HH:mm') }}
+              <div class="event-workshop-decorator">until</div>
+              {{ workshop.time.clone().add(workshop.duration, 'minutes').format('HH:mm') }}
+            {% endif %}
+          </div>
+          <div class="event-workshop-description">
+            {{ workshop.description }}
+          </div>
+        </div>
+      {% endfor %}
+    </div> #}
+  </div>
+</section>
+
+<section class="section-event-prizes" id="prizes">
+  <div class="content-wrapper">
+    {% macro renderPrizes(prizes) %}
+      {% for prize in prizes %}
+        <div class="event-prize{% if prize.class %} event-prize-decorate-{{ prize.class}}{% endif %}">
+          <div class="event-prize-inner">
+            <h3>{{ prize.name }}</h3>
+            <p class="event-prize-content">{{ prize.prize }}</p>
+            {{ prize.description }}
+          </div>
+        </div>
+      {% endfor %}
+    {% endmacro %}
+
+    <div class="event-tba">
+      <h2 class="grand-heading">Prizes</h2>
+      <p>Prizes will be announced soon!</p>
+      {# <div class="event-prizes-general event-prize-container">
+        {{ renderPrizes(prizes.general) }}
+      </div> #}
+      <h2 class="grand-heading">API Prizes</h2>
+      <p>API prizes will be announced soon!</p>
+      {# <div class="event-prize-container event-prizes-api">
+        {{ renderPrizes(prizes.api) }}
+      </div> #}
+    </div>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/3238878/22154258/b920f35c-df22-11e6-9666-874fe6241d6f.png)

This is a quick re-hash of last year's event page with the rendering of a whole bunch of stuff commented out and friendly "TBA" notices on those areas. Currently, we're outputting some general info and the schedule.

I'm opting not to make this a WIP branch with us working on it because this is ready to be seen by the public, but we should iterate on it pretty quickly.

@jaredkhan @varkor what do you think?