### PR TITLE
Fixes issues with the config of our development database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2'
 services:
   db:
-    image: kiasaki/alpine-postgres
+    image: postgres:9.6-alpine
     ports:
       - "5432:5432"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "pusher-js": "^4.0.0",
     "querystring": "^0.2.0",
     "run-sequence": "^1.1.4",
-    "sequelize": "3",
+    "sequelize": "^3.24.8",
     "socket.io": "^1.4.5",
     "socket.io-client": "^1.4.5",
     "stripe": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "pusher-js": "^4.0.0",
     "querystring": "^0.2.0",
     "run-sequence": "^1.1.4",
-    "sequelize": "^3.24.8",
+    "sequelize": "3",
     "socket.io": "^1.4.5",
     "socket.io-client": "^1.4.5",
     "stripe": "^4.1.0",


### PR DESCRIPTION
Use postgres 9.6-alpine in place of alpine-postgres for the development docker file.

We originally used alpine-postgres as it was lighter than postgres from the library.  However alpine-postgres is currently broken, and postgres 9.6-alpine is just as light.