### PR TITLE
Make eslint a prod dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "css-loader": "^0.21.0",
     "del": "^2.0.2",
     "dotenv": "^4.0.0",
+    "eslint": "^4.8.0",
     "express": "^4.13.3",
     "express-session": "^1.14.2",
     "extract-text-webpack-plugin": "^0.9.0",
@@ -48,6 +49,7 @@
     "google-spreadsheet": "^1.1.3",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",
+    "gulp-eslint": "^4.0.0",
     "gulp-if": "^2.0.0",
     "gulp-load-plugins": "^1.0.0",
     "gulp-plumber": "^1.0.1",
@@ -95,8 +97,6 @@
     "yargs": "^6.5.0"
   },
   "devDependencies": {
-    "eslint": "^4.8.0",
-    "gulp-eslint": "^4.0.0",
     "mocha": "^2.3.4",
     "sequelize-cli": "^2.4.0"
   }


### PR DESCRIPTION
This solves issues with production due to `require`'s semantics with dependencies which should be optional.