### PR TITLE
Generate description programmatically

### DIFF
--- a/src/js/server/index.js
+++ b/src/js/server/index.js
@@ -9,6 +9,7 @@ let app = express();
 const auth = require('js/server/auth');
 const errors = require('js/server/errors');
 const colors = require('js/shared/colors');
+const metadata = require('js/shared/metadata');
 
 let server = require('http').Server(app);
 
@@ -19,7 +20,8 @@ process.on('unhandledRejection', (reason, promise) => {
 utils.init(app);
 
 app.use((req, res, next) => {
-  res.locals.title = 'Hack Cambridge';
+  res.locals.title = metadata.title;
+  res.locals.description = metadata.description;
   res.locals.colors = colors;
   const port = (app.settings.env == 'development') ? ':' + req.app.settings.port : '';
   const protocol = (app.settings.env == 'development') ? req.protocol : 'https';

--- a/src/js/shared/application-form.js
+++ b/src/js/shared/application-form.js
@@ -3,7 +3,7 @@ const countries = require('country-list')();
 const validator = require('validator');
 const { field: fileField, typeValidator: fileTypeValidator, sizeValidator: fileSizeValidator } = require('./file-field');
 const { multiCheckboxWidget } = require('./checkbox');
-const { getHackathonStartDate } = require('./dates');
+const { getEarliestGraduationDateToAccept } = require('./dates');
 
 /**
  * Allows us to optimise the list creation by only making it once, lazily.
@@ -157,16 +157,12 @@ exports.createApplicationForm = function createApplicationForm(validateFile = tr
       cssClasses,
       row_units: 'three',
     }),
-    /**
-     * MLH requires attendees to be students or to have graduated within the last 12 months.
-     * https://mlh.io/faq#i-just-graduated-can-i-still-come-to-an-event
-     */
     confirmations: fields.array({
       label: 'Student status confirmation and terms and conditions',
       note: 'We need confirmation of your student status, and you need to accept the terms and conditions, privacy policy, and the MLH Code of Conduct.<br><a href="/terms-and-conditions" target="_blank">Terms and conditions</a><br><a href="/privacy-policy" target="_blank">Privacy policy</a><br><a href="http://static.mlh.io/docs/mlh-code-of-conduct.pdf" target="_blank">MLH Code of Conduct</a>',
       widget: multiCheckboxWidget(),
       choices: {
-        student_status: `I’m currently a student, or I graduated after ${getHackathonStartDate().subtract(1, 'year').format('LL')}.`,
+        student_status: `I’m currently a student, or I graduated after ${getEarliestGraduationDateToAccept().format('LL')}.`,
         terms: 'I accept the terms and conditions, privacy policy, and the MLH Code of Conduct.',
       },
       validators: [

--- a/src/js/shared/dates.js
+++ b/src/js/shared/dates.js
@@ -1,5 +1,26 @@
 const moment = require('moment');
 
-exports.getHackathonStartDate = function () {
+function getHackathonStartDate() {
   return moment('2018-01-19');
+}
+
+function getHackathonEndDate() {
+  return getHackathonStartDate().add(1, 'day');
+}
+
+/**
+ * Returns the earliest graduation date we can accept.
+ * 
+ * This is due to the restriction imposed by MLH that attendees must either be students or
+ * graduates who have graduated within the 12 months prior to the event.
+ * https://mlh.io/faq#i-just-graduated-can-i-still-come-to-an-event
+ */
+function getEarliestGraduationDateToAccept() {
+  return getHackathonStartDate().subtract(1, 'year');
+}
+
+module.exports = {
+  getHackathonStartDate,
+  getHackathonEndDate,
+  getEarliestGraduationDateToAccept
 };

--- a/src/js/shared/metadata.js
+++ b/src/js/shared/metadata.js
@@ -1,0 +1,15 @@
+const { getHackathonStartDate, getHackathonEndDate } = require('./dates');
+
+function createDescription() {
+  if (!getHackathonStartDate().isSame(getHackathonEndDate(), 'month')) {
+    throw new Error('Hackathon start and end dates must be in the same month to create description');
+  }
+
+  const formattedDateRange = getHackathonStartDate().format('MMMM D') + ' – ' + getHackathonEndDate().format('D');
+  
+  return `Join us for 24 hours of building, breaking and creating in the heart of Cambridge from ${formattedDateRange}.`;
+}
+
+module.exports.description = createDescription();
+
+module.exports.title = 'Hack Cambridge';

--- a/src/views/base.html
+++ b/src/views/base.html
@@ -4,10 +4,10 @@
 <head>
     <title>{% block pageTitle %}{{ title }}{% endblock %}</title>
     <meta name="title" content="{{ title }}" />
-    <meta name="description" content="Join us for 24 hours of building, breaking and creating in the heart of Cambridge from January 28 – 29." />
+    <meta name="description" content="{{ description }}" />
     <meta property="og:title" content="{{ title }}" />
     <meta property="og:url" content="{{ requestedUrl.href }}" />
-    <meta property="og:description" content="Join us for 24 hours of building, breaking and creating in the heart of Cambridge from January 28 – 29." />
+    <meta property="og:description" content="{{ description }}" />
     <meta property="og:image" content="{{ requestedUrl.protocol }}//{{ requestedUrl.host }}{{ asset('images/fb-share.jpg') }}" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/views/ternary-base.html
+++ b/src/views/ternary-base.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>{% block pageTitle %}{{ title }} — Hack Cambridge{% endblock %}</title>
     <meta name="title" content="{{ title | default('Hack Cambridge') }}" />
-    <meta name="description" content="{{ description | default('Join us for 24 hours of building, breaking and creating in the heart of Cambridge from January 28 – 29.') }}" />
+    <meta name="description" content="{{ description }}" />
     <meta name=keywords content="{{ keywords | default('hack,Cambridge,ternary 2018') }}">
     <meta name=author content="Hack Cambridge Team">
     <meta name="language" content="en">


### PR DESCRIPTION
Generate the default description for the web pages programmatically from the dates defined in dates.js, to help make dates.js a single source of truth for the dates of the hackathon.