### PR TITLE
Revert "Exclude h5 children"

### DIFF
--- a/src/styles/hc-2018/ternary.styl
+++ b/src/styles/hc-2018/ternary.styl
@@ -128,7 +128,7 @@ section, a, a::after, svg, input, button, .secondary {
 
 /* Fonts */
 
-html *:not(strong):not(h1):not(h2):not(h3):not(h5):not(h4):not(span):not(a):not(h5 *) {
+html *:not(strong):not(h1):not(h2):not(h3):not(h5):not(h4):not(span):not(a) {
     font-family: "PxGroteskRegular", Helvetica, Arial, sans-serif;
 }
 h1, h2, h5, h5 * {


### PR DESCRIPTION
Reverts hackcambridge/hack-cambridge-website#372.

Reverting due to a styling bug affecting the font on the splash page for Firefox and Chrome on Windows