### PR TITLE
Remove deadline banners

### DIFF
--- a/src/views/apply/dashboard.html
+++ b/src/views/apply/dashboard.html
@@ -1,5 +1,4 @@
 {% extends 'default.html' %}
-{% from "macros/alerts.html" import banner as banner %}
 {% set title = 'Apply for Hack Cambridge' %}
 {% set footer = true %}
 {% set is_dashboard = true %}
@@ -37,8 +36,6 @@
 
     {# To obtain this link, see https://stackoverflow.com/a/44883343/618502 and https://api.slack.com/docs/deep-linking #}
     {% set openSlackLink = "slack://open?team=T7YPKKJRZ" %}
-    
-    {{ banner("The clock is ticking…", "You have until the 9<sup>th</sup> December to complete your application!", "two half") }}
 
     {# Section for info about RSVPs #}
     {% if rsvpStatus == statuses.rsvp.INCOMPLETE or rsvpStatus == statuses.rsvp.COMPLETE_EXPIRED %}

--- a/src/views/apply/index.html
+++ b/src/views/apply/index.html
@@ -1,5 +1,4 @@
 {% extends 'default.html' %}
-{% from "macros/alerts.html" import banner as banner %}
 {% set title = 'Apply' %}
 {% set homeLink = true %}
 {% set footer = true %}
@@ -30,7 +29,4 @@
         <a href="/apply/form">Log in with MyMLH</a>
     </div>
 </div>
-{% endblock %}
-{% block extraSections %}
-{{ banner("The clock is ticking…", "You have until the 9<sup>th</sup> December to complete your application!", "two half") }}
 {% endblock %}


### PR DESCRIPTION
Remove the deadline banners from the application pages to complete the soft closure of applications