### PR TITLE
Fix whitespace preservation

### DIFF
--- a/src/styles/hc-2018/ternary.styl
+++ b/src/styles/hc-2018/ternary.styl
@@ -231,7 +231,9 @@ li {
 a:not(.logo) {
     color: var(--accent-color);
     text-decoration: none;
-    white-space: pre-wrap;
+}
+a::after {
+    white-space: pre;
 }
 a:not(.logo)::after {
     content: " →";


### PR DESCRIPTION
White space should be preserved before the arrow only. Fixes #410.