### PR TITLE
Fix application title overlap

### DIFF
--- a/src/views/index.html
+++ b/src/views/index.html
@@ -66,8 +66,8 @@
     </section>
     <section grid="grid" sidebar columns="7.0" color="red">
       <div></div>
-      <div grid="rows" rows="1.5">
-        <strong rows="0.5">
+      <div grid="rows" rows="2.0">
+        <strong rows="1.0">
           Applications for Hack Cambridge 2019 open soon.
         </strong>
         <p rows="0.5">


### PR DESCRIPTION
Currently the website has an overlap between the application title and subtitle: 

<img width="1440" alt="screen shot 2018-10-13 at 12 19 22" src="https://user-images.githubusercontent.com/20166594/46904909-99eacc80-cee3-11e8-966b-def71cd1bc89.png">

I've changed a few of the row numbers to create extra-room for the title and the bounding red box: 

<img width="1440" alt="screen shot 2018-10-13 at 12 19 07" src="https://user-images.githubusercontent.com/20166594/46904914-abcc6f80-cee3-11e8-870d-18fbbc6505ce.png">

Also there seems to be quite a few errors with the grid-system when viewed on something like an iPhone 6, these seem more systemic so I thought I would fix this bug first.