### PR TITLE
Add day applications close to FAQ

### DIFF
--- a/assets/resources/faqs.yml
+++ b/assets/resources/faqs.yml
@@ -51,7 +51,7 @@ faqs:
     answer: We love ’em! We’ll provide the basics (soldering kits, breadboards, etc.) and you do the rest. Do bring along any special equipment you might want to hack on as well.
 
   - question: When do applications close?
-    answer: Applications close in <%= dates.getAdvertisedApplicationsEnd().format('MMMM YYYY') %>.
+    answer: Applications close on <%= dates.getAdvertisedApplicationsEnd().format('MMMM Do') %>.
 
   - question: When will I find out whether I was accepted as a participant of Hack Cambridge <%= theme.getEventName() %>?
     answer: We will be sending out invitations on a rolling basis as applications come in. If you’re coming from far away, we’ll aim to get back to you as soon as possible to give you time to sort out travel arrangements.


### PR DESCRIPTION
We've published this on Facebook so it makes sense to refine the date on the website too.