### PR TITLE
Remove getAdvertisedApplicationsEnd

### DIFF
--- a/assets/resources/dashboard.yml
+++ b/assets/resources/dashboard.yml
@@ -74,7 +74,7 @@ dashboard:
       content:
         You didn’t apply as part of a team. Applying as a team means your applications will be reviewed together and either all or none of you will be invited.
       action:
-        title: Submit a team application before <%= dates.getAdvertisedApplicationsEnd().format('MMMM Do') %>
+        title: Submit a team application before <%= dates.getApplicationsEnd().format('MMMM Do') %>
         location: /apply/team
     wanting:
       type: success

--- a/assets/resources/faqs.yml
+++ b/assets/resources/faqs.yml
@@ -51,7 +51,7 @@ faqs:
     answer: We love ’em! We’ll provide the basics (soldering kits, breadboards, etc.) and you do the rest. Do bring along any special equipment you might want to hack on as well.
 
   - question: When do applications close?
-    answer: Applications close on <%= dates.getAdvertisedApplicationsEnd().format('MMMM Do') %>.
+    answer: Applications close on <%= dates.getApplicationsEnd().format('MMMM Do') %>.
 
   - question: When will I find out whether I was accepted as a participant of Hack Cambridge <%= theme.getEventName() %>?
     answer: We will be sending out invitations on a rolling basis as applications come in. If you’re coming from far away, we’ll aim to get back to you as soon as possible to give you time to sort out travel arrangements.

--- a/src/shared/dates.ts
+++ b/src/shared/dates.ts
@@ -5,7 +5,9 @@ export function getApplicationsStart(): moment.Moment {
 }
 
 /**
- * Links to start applications will be removed from this date.
+ * The date that applications close.
+ * Links to start applications will be removed from this date, however
+ * applications that have already been started can still be completed.
  */
 export function getApplicationsEnd(): moment.Moment {
   return moment('2018-12-17T23:59:00Z');
@@ -17,15 +19,6 @@ export function getHackathonStartDate(): moment.Moment {
 
 export function getHackathonEndDate(): moment.Moment {
   return moment('2019-01-20');
-}
-
-/**
- * Returns the datetime applications are advertised to close. This is the closing date
- * displayed to hackers. Applications won't actually close until `getApplicationsEnd`, at
- * which point links to start applications will be removed.
- */
-export function getAdvertisedApplicationsEnd(): moment.Moment {
-  return moment('2018-12-17T23:59:59Z');
 }
 
 /**

--- a/views/index.pug
+++ b/views/index.pug
@@ -53,13 +53,13 @@ block content
           p We’ll be publishing an event page very soon! In it, you'll find a schedule, maps and directions, listings of APIs, hardware, prizes, and more.
           //-a(href="/event") Find all the information you need on the event page
       div
-    if moment().isAfter(event.dates.getAdvertisedApplicationsEnd().subtract(1, 'weeks')) && moment().isBefore(event.dates.getAdvertisedApplicationsEnd())
+    if moment().isAfter(event.dates.getApplicationsEnd().subtract(1, 'weeks')) && moment().isBefore(event.dates.getApplicationsEnd())
       section(grid='grid' sidebar='' columns='7.5' color='blue')
         div
         div(grid='rows' rows='1.0')
-          if moment().isBefore(event.dates.getAdvertisedApplicationsEnd().subtract(2, 'day'))
+          if moment().isBefore(event.dates.getApplicationsEnd().subtract(2, 'day'))
             strong(rows='0.5') Applications close this #{event.dates.getApplicationsEnd().format('dddd')}!
-          else if moment().isBefore(event.dates.getAdvertisedApplicationsEnd().subtract(1, 'day'))
+          else if moment().isBefore(event.dates.getApplicationsEnd().subtract(1, 'day'))
             strong(rows='0.5') Applications close tomorrow!
           else
             strong(rows='0.5') Applications close today at #{event.dates.getApplicationsEnd().format('HH:mm')}!
@@ -75,8 +75,8 @@ block content
               | Applications for Hack Cambridge 2019 open soon.
             else
               | Applications open this #{event.dates.getApplicationsStart().format('dddd')}!
-          else if moment().isBefore(event.dates.getAdvertisedApplicationsEnd())
-            if moment().isAfter(event.dates.getAdvertisedApplicationsEnd().subtract(1, 'weeks'))
+          else if moment().isBefore(event.dates.getApplicationsEnd())
+            if moment().isAfter(event.dates.getApplicationsEnd().subtract(1, 'weeks'))
               | Applications close soon!
             else
               | Applications are open!


### PR DESCRIPTION
This wasn't a logical distinction to have, since we already have separate control over removing links to start applications and blocking all applications from being submitted.